### PR TITLE
ANNOTATION_NO_LONGER_PRESENT should be BREAKING for binary

### DIFF
--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Code.java
@@ -104,7 +104,7 @@ public enum Code {
         POTENTIALLY_BREAKING, "annotationType"),
     ANNOTATION_NOW_INHERITED("java.annotation.nowInherited", NON_BREAKING, NON_BREAKING, POTENTIALLY_BREAKING,
             "annotationType"),
-    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, NON_BREAKING, POTENTIALLY_BREAKING),
+    ANNOTATION_NO_LONGER_PRESENT("java.annotation.noLongerPresent", BREAKING, BREAKING, POTENTIALLY_BREAKING),
 
     FIELD_ADDED_STATIC_FIELD("java.field.addedStaticField", NON_BREAKING, NON_BREAKING, null),
     FIELD_ADDED("java.field.added", NON_BREAKING, NON_BREAKING, null),


### PR DESCRIPTION
This is definitely breaking for us:

```
Old API: error_prone_annotations-2.0.18.jar
New API: error_prone_annotations-2.3.3.jar
old: @interface com.google.errorprone.annotations.DoNotMock
new: <none>
java.annotation.noLongerPresent: Old API referenced the annotation type but the new API version no longer does.
SOURCE: BREAKING, SEMANTIC: POTENTIALLY_BREAKING, BINARY: NON_BREAKING
```

@jhaber @kmclarnon