### PR TITLE
Exit with nonzero code for exceptions

### DIFF
--- a/revapi-standalone/src/main/java/org/revapi/standalone/Main.java
+++ b/revapi-standalone/src/main/java/org/revapi/standalone/Main.java
@@ -278,6 +278,7 @@ public final class Main {
                     configFiles, additionalConfigOptions, remoteRepositories);
         } catch (Exception e) {
             e.printStackTrace();
+            System.exit(1);
         }
 
         System.exit(0);


### PR DESCRIPTION
This will prevent things from carrying on as usual if something goes wrong with revapi.

@snommit-mit @stevegutz @kmclarnon 