### PR TITLE
Ignore completion errors that happen when making a human-readable string

### DIFF
--- a/revapi-java-spi/src/main/java/org/revapi/java/spi/Util.java
+++ b/revapi-java-spi/src/main/java/org/revapi/java/spi/Util.java
@@ -654,7 +654,7 @@ public final class Util {
             int depth = state.depth;
 
             CharSequence name;
-            if (t.getEnclosingType().getKind() != TypeKind.NONE) {
+            if (IgnoreCompletionFailures.in(() -> t.getEnclosingType().getKind()) != TypeKind.NONE) {
                 state.depth--; // we need to visit the parent with the same depth as this type
                 visit(t.getEnclosingType(), state);
                 state.depth = depth;


### PR DESCRIPTION
If a symbol is not completed when revapi goes to print stats, it blows up because it has exited the part of the code that contains protections against completion errors.

@snommit-mit @kmclarnon @stevegutz 